### PR TITLE
セッションの有効期限を.envから設定できるようにして、デフォルト値も用意する

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -29,7 +29,7 @@ return [
     |
     */
 
-    'lifetime' => 120,
+    'lifetime' => env('SESSION_LIFETIME', 7*24*60),
 
     'expire_on_close' => false,
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class SessionTest extends \TestCase
+{
+    public function testCatchDefault()
+    {
+        $application = $this->createApplication();
+        $this->assertEquals(config('session.lifetime'), 7*24*60);
+    }
+
+    public function testCatch()
+    {
+        putenv('SESSION_LIFETIME=1');
+        $application = $this->createApplication();
+        $this->assertEquals(config('session.lifetime'), 1);
+    }
+}


### PR DESCRIPTION
#9 の対応。なお、有効期限は1週間