### PR TITLE
バッククオート以外でcodeブロックと認識された場合にfilenameがないため、なくても表示できるようにする

### DIFF
--- a/app/Extra/QiitaMarkdown.php
+++ b/app/Extra/QiitaMarkdown.php
@@ -37,6 +37,7 @@ class QiitaMarkdown extends GithubMarkdown
      */
     protected function renderCode($block)
 	{
+        $block['filename'] = isset($block['filename']) ? $block['filename'] : '';
         $template = <<< END_OF_FORMAT
 <div class="code-frame" data-lang="text">
 <div class="code-lang"><span class="bold">%s</span></div>


### PR DESCRIPTION
#31 を直接解消するわけではないが、ありそうなエラーは回避可能。

元Issue自体はもうしばらく継続予定